### PR TITLE
Node recursivity scrape bug fix

### DIFF
--- a/src/methods/artoo.methods.scrape.js
+++ b/src/methods/artoo.methods.scrape.js
@@ -56,9 +56,9 @@
     // Transforming to selector
     var $iterator;
     if (typeof iterator === 'function')
-      $iterator = artoo.$(iterator(artoo.$));
+      $iterator = $(iterator($));
     else
-      $iterator = artoo.$(iterator);
+      $iterator = $(iterator);
 
     // Iteration
     $iterator.each(function(i) {

--- a/src/methods/artoo.methods.scrape.js
+++ b/src/methods/artoo.methods.scrape.js
@@ -45,7 +45,8 @@
 
   // Scraping function after polymorphism has been taken care of
   function scrape(iterator, data, params, cb) {
-    var scraped = [],
+    var $ = artoo.$,
+        scraped = [],
         loneSelector = !!data.attr || !!data.method || data.scrape ||
                        typeof data === 'string' ||
                        typeof data === 'function';

--- a/test/suites/node.test.js
+++ b/test/suites/node.test.js
@@ -36,4 +36,25 @@ describe('artoo.node', function() {
 
     assert.deepEqual(artoo.scrape('li'), ['item1', 'item2']);
   });
+
+  it('should be possible to scrape recursively.', function() {
+    var $ = cheerio.load([
+      '<ul class="list">',
+        '<li>',
+          '<ul class="sublist"><li>item1-1</li><li>item1-2</li></ul>',
+        '</li>',
+        '<li>item2',
+          '<ul class="sublist"><li>item2-1</li><li>item2-2</li></ul>',
+        '</li>',
+      '</ul>'].join('\n'));
+
+    artoo.setContext($);
+
+    assert.deepEqual(artoo.scrape('ul.list > li', {
+      scrape: {
+        iterator: 'ul.sublist > li',
+        data: 'text'
+      }
+    }), [['item1-1', 'item1-2'], ['item2-1', 'item2-2']]);
+  });
 });


### PR DESCRIPTION
Discovered an issue when running a recursive scrape via Node.js. The fix was to ensure that the `$` variable is set from `artoo.$` in the scrape function.

Provided a unit test to demonstrate fixed recursivity bug when run via Node. Example is taken verbatim from the [artoo documentation](http://medialab.github.io/artoo/scrape/#recursivity) on
recursivity.