### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
     "scraping",
     "webscraper"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/medialab/artoo/blob/master/LICENSE.txt"
-  },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/medialab/artoo/issues"
   },


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)