### PR TITLE
ajaxSniffer - Added support for responses which don't contain content type 

### DIFF
--- a/src/methods/artoo.methods.ajaxSniffer.js
+++ b/src/methods/artoo.methods.ajaxSniffer.js
@@ -123,7 +123,7 @@
             var contentType = xhr.getResponseHeader('Content-Type'),
                 data = xhr.response;
 
-            if (~contentType.search(/json/)) {
+            if (contentType && ~contentType.search(/json/)) {
               try {
                 data = JSON.parse(xhr.responseText);
               }
@@ -131,8 +131,14 @@
                 // pass...
               }
             }
-            else if (~contentType.search(/xml/)) {
+            else if (contentType && ~contentType.search(/xml/)) {
               data = xhr.responseXML;
+            } else {
+              try {
+                data = JSON.parse(xhr.responseText);
+              } catch (e) {
+                data = xhr.responseText;
+              }
             }
 
             callback.call(xhr, xhr._spy, {


### PR DESCRIPTION
Encountered the following error:
Uncaught TypeError: Cannot read property 'search' of null

It turned out the site wasn't returning a content type header at all.

I couldn't find any appropriate test but I've manually tested it on the offending site and on google.