### PR TITLE
Fix missing quotes in CSP header overrides

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -33,8 +33,8 @@
           o.value = 
             "default-src *;" +
             "script-src * 'unsafe-inline' 'unsafe-eval';" +
-            "connect-src * 'unsafe-inline' 'unsafe-eval;" +
-            "style-src * 'unsafe-inline;";
+            "connect-src * 'unsafe-inline' 'unsafe-eval';" +
+            "style-src * 'unsafe-inline';";
       }
 
       return {


### PR DESCRIPTION
Some single quotation marks were not closed in the Content Security Policy headers, which broke inline styles and certain other features on many sites in Chrome 55.