### PR TITLE
Scrape method to allow arrow functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - "7"

--- a/src/methods/artoo.methods.scrape.js
+++ b/src/methods/artoo.methods.scrape.js
@@ -23,7 +23,7 @@
       val = o.call(scope, $);
     }
     else if (typeof o.method === 'function')
-      val = o.method.call($sel.get(), $);
+      val = o.method.call($sel.get(), $, $sel.get());
     else if (typeof o === 'string') {
       if (typeof $sel[o] === 'function')
         val = $sel[o]();

--- a/test/suites/scrape.test.js
+++ b/test/suites/scrape.test.js
@@ -211,6 +211,25 @@
           artoo.scrape(id + ' .views-row', {
             url: {
               sel: 'a',
+              method: function($, el) {
+                return $(el).attr('href');
+              }
+            },
+            title: {
+              sel: 'a',
+              method: function($, el) { 
+                return $(el).text();
+              }
+            }
+          }),
+          list,
+          'Scraping the list with methods el param should return the correct array.'
+        );
+
+        assert.deepEqual(
+          artoo.scrape(id + ' .views-row', {
+            url: {
+              sel: 'a',
               method: function() {
                 return;
               },


### PR DESCRIPTION
This is a syntactic sugar for allowing the use of arrow functions for browsers or environments that allow it. I pass the element context in the method function as the second parameter, exposing it in addition to `this`. It is a backward compatible change.

```js
artoo.scrape('tr tr:has(td.title:has(a)):not(:last)', {
  domain: {
    sel: '.comhead',
    method: ($, el) => $(el).text().trim().replace(/[\(\)]/g, '')
  }
});
```