### PR TITLE
Add scrape's arrow function ability to the documentation

### DIFF
--- a/scrape.md
+++ b/scrape.md
@@ -155,6 +155,15 @@ artoo.scrape('ul > li', {
 })
 ```
 
+Additionally, a reference to the current DOM element in the iteration is passed in as the second parameter to the function `function($, el)`. This will enable the use of arrow functions.
+
+```js
+artoo.scrape('ul > li', {
+  text: ($, el) => $(el).text(),
+  nb: ($, el) => +$(el).attr('data-nb')
+})
+```
+
 <h3 id="recursivity">Recursivity</h3>
 
 If you need recursivity within the `artoo.scrape` method, rather that calling the method itself in a function retriever, you can also pass an object with the scrape property like in the example below.


### PR DESCRIPTION
Adding documentation to coincide with https://github.com/medialab/artoo/pull/273

The travis build is failing for me, however.
```
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
/home/travis/.rvm/gems/ruby-2.4.1@global/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
The command "rake" exited with 1.
```